### PR TITLE
fix link to documentation

### DIFF
--- a/themes/default/config.twig
+++ b/themes/default/config.twig
@@ -6,7 +6,7 @@
 {% endblock %}
 {% block content %}
             <h2>{% trans "Saving articles" %}</h2>
-            <p>{% trans "There are several ways to save an article:" %} {% trans "(<a href=\"http://doc.wallabag.org/en/User_documentation/Save_your_first_article\" target=\"_blank\" title=\"Documentation\">?</a>)" %}</p>
+            <p>{% trans "There are several ways to save an article:" %} {% trans "(<a href=\"http://doc.wallabag.org/en/User_documentation/save_your_first_article\" target=\"_blank\" title=\"Documentation\">?</a>)" %}</p>
             <p>
                 <form method="get" action="index.php">
                     <label class="addurl" for="config_plainurl">{% trans "By filling this field" %}:</label><br>


### PR DESCRIPTION
fix link to Save your first article (no capital letters in documentation pages)